### PR TITLE
Backport fix from django-wkhtmltopdf that includes request in context

### DIFF
--- a/puppeteer_pdf/utils.py
+++ b/puppeteer_pdf/utils.py
@@ -263,17 +263,19 @@ def make_absolute_paths(content):
 def render_to_temporary_file(template, context, request=None, mode='w+b',
                              bufsize=-1, suffix='.html', prefix='tmp',
                              dir=None, delete=True):
-    if django.VERSION < (1, 8):
-        # If using a version of Django prior to 1.8, ensure ``context`` is an
-        # instance of ``Context``
-        if not isinstance(context, Context):
-            if request:
-                context = RequestContext(request, context)
-            else:
-                context = Context(context)
-    # Handle error when ``request`` is None
     try:
-        content = template.render(context)
+        if django.VERSION < (1, 8):
+            # If using a version of Django prior to 1.8, ensure ``context`` is an
+            # instance of ``Context``
+            if not isinstance(context, Context):
+                if request:
+                    context = RequestContext(request, context)
+                else:
+                    context = Context(context)
+            # Handle error when ``request`` is None
+            content = template.render(context)
+        else:
+            content = template.render(context, request)
     except AttributeError:
         content = loader.render_to_string(template, context)
 


### PR DESCRIPTION
Thanks for the port to `puppeteer`!

This PR backports a fix from the upstream project that ensures request is a passed to `template.render`, which is required to make use of Django's built-in [request context processor](https://docs.djangoproject.com/en/2.0/_modules/django/template/context_processors/)

See [django-wkhtmltopdf #145](https://github.com/incuna/django-wkhtmltopdf/pull/145/) for additional context.