### PR TITLE
Fix bug that leads to no output when PUPPETEER_PDF_CMD_OPTIONS is configured

### DIFF
--- a/puppeteer_pdf/utils.py
+++ b/puppeteer_pdf/utils.py
@@ -71,10 +71,11 @@ def puppeteer_to_pdf(input, output=None, **kwargs):
     # Default options:
     options = getattr(settings, 'PUPPETEER_PDF_CMD_OPTIONS', None)
     if options is None:
-        options = {'path': output}
+        options = {}
     else:
         options = copy(options)
     options.update(kwargs)
+    options['path'] = output
 
     cmd = 'PUPPETEER_PDF_CMD'
     CHROME_LOCATION = 'puppeteer-pdf'  # default


### PR DESCRIPTION
If `PUPPETEER_PDF_CMD_OPTIONS` is configured in the Django settings without a `'path'` key, then no `--path` argument is passed to puppeteer-pdf. In that case, an empty response is returned. It seems like one should be able to configured options without specifying a specific path to use every time, so I fixed it to always include a path key. Let me know if that seems reasonable.